### PR TITLE
Minor ui usability tweaks for identifying renderable nodes

### DIFF
--- a/CrossMod/GUI/AnimationBar.cs
+++ b/CrossMod/GUI/AnimationBar.cs
@@ -14,7 +14,7 @@ namespace CrossMod.GUI
             {
                 return animationTrack.Maximum;
             }
-            set
+            protected set
             {
                 animationTrack.Maximum = value;
                 totalFrame.Maximum = value;
@@ -37,7 +37,35 @@ namespace CrossMod.GUI
 
         public RModel Model;
         public RSkeleton Skeleton;
-        public IRenderableAnimation Animation;
+
+        private IRenderableAnimation animation;
+
+        /**
+         * Sets the current animation.
+         * Setting it to null stops playback, setting it when an animation
+         * is ongoing starts a new animation but from frame 0.
+         */
+        public IRenderableAnimation Animation
+        {
+            get
+            {
+                return animation;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    Stop();
+                    animation = null;
+                }
+                else if (animation != value)
+                {
+                    animation = value;
+                    FrameCount = value.GetFrameCount();
+                    Frame = 0;
+                }
+            }
+        }
 
         private Timer AnimationPlayer;
 
@@ -46,6 +74,18 @@ namespace CrossMod.GUI
             InitializeComponent();
             animationTrack.TickFrequency = 1;
             SetupTimer();
+        }
+
+        public void Start()
+        {
+            playButton.Text = "||";
+            AnimationPlayer.Start();
+        }
+
+        public void Stop()
+        {
+            playButton.Text = ">";
+            AnimationPlayer.Stop();
         }
 
         private void SetupTimer()
@@ -80,13 +120,11 @@ namespace CrossMod.GUI
         {
             if (playButton.Text.Equals(">"))
             {
-                playButton.Text = "||";
-                AnimationPlayer.Start();
+                Start();
             }
             else
             {
-                playButton.Text = ">";
-                AnimationPlayer.Stop();
+                Stop();
             }
         }
     }

--- a/CrossMod/GUI/AnimationBar.cs
+++ b/CrossMod/GUI/AnimationBar.cs
@@ -62,7 +62,17 @@ namespace CrossMod.GUI
                 {
                     animation = value;
                     FrameCount = value.GetFrameCount();
-                    Frame = 0;
+
+                    // Set frame to 0 and ensure the animation always re-renders on swap.
+                    // Value change events don't trigger if the value doesn't change.
+                    if (Frame == 0)
+                    {
+                        UpdateAnimation();
+                    }
+                    else
+                    {
+                        Frame = 0;
+                    }
                 }
             }
         }
@@ -96,6 +106,21 @@ namespace CrossMod.GUI
             };
             AnimationPlayer.Tick += new EventHandler(animationTimer_Tick);
         }
+        
+        /**
+         * Updates the held animation object to hold the current state.
+         * This includes the model, skeleton, and current frame.
+         */
+        private void UpdateAnimation()
+        {
+            if (Animation == null)
+            {
+                return;
+            }
+
+            Animation.SetFrameModel(Model, Frame);
+            Animation.SetFrameSkeleton(Skeleton, Frame);
+        }
 
         private void animationTimer_Tick(object sender, EventArgs e)
         {
@@ -112,8 +137,7 @@ namespace CrossMod.GUI
         private void animationTrack_ValueChanged(object sender, EventArgs e)
         {
             currentFrame.Value = animationTrack.Value;
-            Animation.SetFrameModel(Model, Frame);
-            Animation.SetFrameSkeleton(Skeleton, Frame);
+            UpdateAnimation();
         }
 
         private void playButton_Click(object sender, EventArgs e)

--- a/CrossMod/GUI/ModelViewport.cs
+++ b/CrossMod/GUI/ModelViewport.cs
@@ -23,17 +23,18 @@ namespace CrossMod.GUI
                 if (value == null)
                 {
                     renderableNode = null;
+                    animationBar.Animation = null;
                     return;
                 }
                 
                 if (value.GetRenderableNode() is IRenderableAnimation anim)
                 {
                     animationBar.Animation = anim;
-                    animationBar.FrameCount = anim.GetFrameCount();
                     controlBox.Visible = true;
                 }
                 else
                 {
+                    animationBar.Animation = null;
                     renderableNode = value.GetRenderableNode();
                 }
 

--- a/CrossMod/GUI/ModelViewport.cs
+++ b/CrossMod/GUI/ModelViewport.cs
@@ -18,20 +18,23 @@ namespace CrossMod.GUI
         {
             set
             {
+                ClearDisplay();
+
                 if (value == null)
+                {
+                    renderableNode = null;
                     return;
+                }
                 
                 if (value.GetRenderableNode() is IRenderableAnimation anim)
                 {
                     animationBar.Animation = anim;
                     animationBar.FrameCount = anim.GetFrameCount();
-                    ClearDisplay();
                     controlBox.Visible = true;
                 }
                 else
                 {
                     renderableNode = value.GetRenderableNode();
-                    ClearDisplay();
                 }
 
                 if (renderableNode is RSkeleton skeleton)

--- a/CrossMod/MainForm.Designer.cs
+++ b/CrossMod/MainForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace CrossMod
+namespace CrossMod
 {
     partial class MainForm
     {
@@ -140,6 +140,7 @@
             // 
             this.fileTree.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
+            this.fileTree.HideSelection = false;
             this.fileTree.ItemHeight = 24;
             this.fileTree.Location = new System.Drawing.Point(12, 27);
             this.fileTree.Name = "fileTree";

--- a/CrossMod/MainForm.cs
+++ b/CrossMod/MainForm.cs
@@ -93,6 +93,11 @@ namespace CrossMod
             if (Node == null)
                 Node = new FileNode();
 
+            // Change style of unrenderable nodes
+            if (!(Node is IRenderableNode)) {
+                Node.ForeColor = Color.Gray;
+            }
+
             Node.Open(file);
 
             Node.Text = Path.GetFileName(file);

--- a/CrossMod/MainForm.cs
+++ b/CrossMod/MainForm.cs
@@ -103,11 +103,12 @@ namespace CrossMod
         {
             if (fileTree.SelectedNode is IRenderableNode renderableNode)
             {
-                if (renderableNode != null)
-                {
-                    ShowModelViewport();
-                    modelViewport.RenderableNode = renderableNode;
-                }
+                ShowModelViewport();
+                modelViewport.RenderableNode = renderableNode;
+            }
+            else
+            {
+                modelViewport.Clear();
             }
 
             modelViewport.RenderFrame();

--- a/CrossMod/MainForm.cs
+++ b/CrossMod/MainForm.cs
@@ -37,7 +37,7 @@ namespace CrossMod
 
         public void ShowModelViewport()
         {
-            HideControl();
+            contentBox.Controls.Clear();
             contentBox.Controls.Add(modelViewport);
         }
 


### PR DESCRIPTION
Non-renderable nodes are grayed out in the file view, selecting an unrenderable node clears the viewport now (instead of keeping a stale render), and losing focus no longer (completely) deselects the current selection.

Example: Pichu (after losing focus on the tree view)
![image](https://user-images.githubusercontent.com/1286721/50609163-f20aec80-0e9c-11e9-982f-7876d613b3dd.png)

Motivator: Built the project out of interest to see how SSBU models work, got confused over which files were model files initially as the viewport wasn't cleared for invalid files.
